### PR TITLE
Require mathlib and define propositional formulas

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,4 +19,4 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: build package
-        run: lake build
+        run: lake exe cache get && lake build

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /build
 /lake-packages/*
 /lean-llvm
+*.olean

--- a/LeanSAT.lean
+++ b/LeanSAT.lean
@@ -3,3 +3,4 @@ import LeanSAT.CNF
 import LeanSAT.Encode
 import LeanSAT.Solver
 import LeanSAT.Preprocess.BlockedClauseElim
+import LeanSAT.Model

--- a/LeanSAT/AuxDefs.lean
+++ b/LeanSAT/AuxDefs.lean
@@ -289,7 +289,7 @@ def List.subtypeSize [SizeOf α] : (L : List α) → List {a : α // sizeOf a < 
 
 @[simp] theorem List.find?_map (p : β → Bool) (f : α → β) (L : List α)
   : List.find? p (List.map f L) = Option.map f (List.find? (p ∘ f) L)
-  := by induction L <;> simp; split <;> simp [*]
+  := by induction L <;> simp [find?]; split <;> simp [*]
 
 /-- Like `forDiagM`, but only runs `f e e'` (not `f e e`). -/
 @[simp] def List.forPairsM [Monad m] (f : α → α → m PUnit) : List α → m PUnit

--- a/LeanSAT/Model.lean
+++ b/LeanSAT/Model.lean
@@ -1,0 +1,2 @@
+import LeanSAT.Model.PropForm
+import LeanSAT.Model.ToMathlib

--- a/LeanSAT/Model/PropForm.lean
+++ b/LeanSAT/Model/PropForm.lean
@@ -1,0 +1,238 @@
+/-
+Copyright (c) 2023 Wojciech Nawrocki. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Wojciech Nawrocki
+-/
+
+import Mathlib.Data.Set.Basic
+import Mathlib.Order.BooleanAlgebra
+
+import LeanSAT.Model.ToMathlib
+
+/-! Formulas of propositional logic.
+
+This modules inductively defines the syntax of formulas.
+Later on we can take a quotient to identify `x ∨ ¬x` with `⊤`, for example. -/
+
+/-- A propositional formula over variables of type `ν`. -/
+inductive PropForm (ν : Type u)
+  | var (x : ν)
+  | tr
+  | fls
+  | neg (φ : PropForm ν)
+  | conj (φ₁ φ₂ : PropForm ν)
+  | disj (φ₁ φ₂ : PropForm ν)
+  | impl (φ₁ φ₂ : PropForm ν)
+  | biImpl (φ₁ φ₂ : PropForm ν)
+  deriving Repr, DecidableEq, Inhabited
+
+namespace PropForm
+
+-- HACK: a `let` doesn't work with structural recursion
+local macro "go " n:ident : term =>
+  `(let s := $(Lean.mkIdent `PropForm.toString) $n
+    if s.contains ' ' then s!"({s})" else s)
+protected def toString [ToString ν] : PropForm ν → String
+  | var x        => toString x
+  | tr           => "⊤"
+  | fls          => "⊥"
+  | neg φ        => s!"¬{go φ}"
+  | conj φ₁ φ₂   => s!"{go φ₁} ∧ {go φ₂}"
+  | disj φ₁ φ₂   => s!"{go φ₁} ∨ {go φ₂}"
+  | impl φ₁ φ₂   => s!"{go φ₁} → {go φ₂}"
+  | biImpl φ₁ φ₂ => s!"{go φ₁} ↔ {go φ₂}"
+
+instance [ToString ν] : ToString (PropForm ν) :=
+  ⟨PropForm.toString⟩
+
+end PropForm
+
+/-- An assignment of truth values to propositional variables. -/
+def PropAssignment (ν : Type u) := ν → Bool
+
+namespace PropAssignment
+
+@[ext] theorem ext (v1 v2 : PropAssignment ν) (h : ∀ x, v1 x = v2 x) : v1 = v2 := funext h
+
+def set [DecidableEq ν] (τ : PropAssignment ν) (x : ν) (v : Bool) :
+    PropAssignment ν :=
+  fun y => if y = x then v else τ y
+
+@[simp]
+theorem set_get [DecidableEq ν] (τ : PropAssignment ν) (x : ν) (v : Bool) :
+    τ.set x v x = v := by
+  simp [set]
+
+theorem set_get_of_ne [DecidableEq ν] {x y : ν} (τ : PropAssignment ν) (v : Bool) :
+    x ≠ y → τ.set x v y = τ y := by
+  intro h
+  simp [set, h.symm]
+
+@[simp]
+theorem set_set [DecidableEq ν] (τ : PropAssignment ν) (x : ν) (v v' : Bool) :
+    (τ.set x v).set x v' = τ.set x v' := by
+  ext x'
+  dsimp [set]; split <;> simp_all
+
+@[simp]
+theorem set_same [DecidableEq ν] (τ : PropAssignment ν) (x : ν) :
+    τ.set x (τ x) = τ := by
+  ext x'
+  dsimp [set]; split <;> simp_all
+
+end PropAssignment
+
+namespace PropForm
+
+/-- The unique extension of `τ` from just variables to formulas. -/
+@[simp]
+def eval (τ : PropAssignment ν) : PropForm ν → Bool
+  | var x => τ x
+  | tr => true
+  | fls => false
+  | neg φ => !(eval τ φ)
+  | conj φ₁ φ₂ => (eval τ φ₁) && (eval τ φ₂)
+  | disj φ₁ φ₂ => (eval τ φ₁) || (eval τ φ₂)
+  | impl φ₁ φ₂ => (eval τ φ₁) ⇨ (eval τ φ₂)
+  | biImpl φ₁ φ₂ => eval τ φ₁ = eval τ φ₂
+
+/-! Satisfying assignments -/
+
+/-- An assignment satisfies a formula `φ` when `φ` evaluates to `⊤` at that assignment. -/
+def satisfies (τ : PropAssignment ν) (φ : PropForm ν) : Prop :=
+  φ.eval τ = true
+
+/-- This instance is scoped so that `τ ⊨ φ : Prop` implies `φ : PropForm _` via the `outParam` only
+when `PropForm` is open. -/
+scoped instance : SemanticEntails (PropAssignment ν) (PropForm ν) where
+  entails := PropForm.satisfies
+
+open SemanticEntails renaming entails → sEntails
+
+variable {τ : PropAssignment ν} {x : ν} {φ φ₁ φ₂ φ₃ : PropForm ν}
+
+@[simp]
+theorem satisfies_var : τ ⊨ var x ↔ τ x := by
+  simp [sEntails, satisfies]
+
+@[simp]
+theorem satisfies_tr : τ ⊨ tr := by
+  simp [sEntails, satisfies]
+
+@[simp]
+theorem not_satisfies_fls : τ ⊭ fls :=
+  fun h => nomatch h
+
+@[simp]
+theorem satisfies_neg : τ ⊨ neg φ ↔ τ ⊭ φ := by
+  simp [sEntails, satisfies]
+
+@[simp]
+theorem satisfies_conj : τ ⊨ conj φ₁ φ₂ ↔ τ ⊨ φ₁ ∧ τ ⊨ φ₂ := by
+  simp [sEntails, satisfies]
+
+@[simp]
+theorem satisfies_disj : τ ⊨ disj φ₁ φ₂ ↔ τ ⊨ φ₁ ∨ τ ⊨ φ₂ := by
+  simp [sEntails, satisfies]
+
+@[simp]
+theorem satisfies_impl : τ ⊨ impl φ₁ φ₂ ↔ (τ ⊨ φ₁ → τ ⊨ φ₂) := by
+  simp only [sEntails, satisfies, eval]
+  cases (eval τ φ₁) <;> simp [himp_eq]
+
+theorem satisfies_impl' : τ ⊨ impl φ₁ φ₂ ↔ τ ⊭ φ₁ ∨ τ ⊨ φ₂ := by
+  simp only [sEntails, satisfies, eval]
+  cases (eval τ φ₁) <;> simp [himp_eq]
+
+@[simp]
+theorem satisfies_biImpl : τ ⊨ biImpl φ₁ φ₂ ↔ (τ ⊨ φ₁ ↔ τ ⊨ φ₂) := by
+  simp [sEntails, satisfies]
+
+theorem satisfies_biImpl' : τ ⊨ biImpl φ₁ φ₂ ↔ ((τ ⊨ φ₁ ∧ τ ⊨ φ₂) ∨ (τ ⊭ φ₁ ∧ τ ⊭ φ₂)) := by
+  simp only [sEntails, satisfies, eval]
+  cases (eval τ φ₁) <;> aesop
+
+/-! Semantic entailment and equivalence. -/
+
+/-- A formula `φ₁` semantically entails `φ₂` when `τ ⊨ φ₁` implies `τ ⊨ φ₂`.
+
+This is actually defined in terms of the Boolean lattice
+and the above statement is a theorem.
+Note that the two-valued Boolean model is universal,
+meaning that this formulation of semantic entailment
+is equivalent to entailment in any Boolean algebra,
+and also (by completeness) to provability. -/
+def entails (φ₁ φ₂ : PropForm ν) : Prop :=
+  ∀ (τ : PropAssignment ν), φ₁.eval τ ≤ φ₂.eval τ
+
+/-- An equivalent formulation of semantic entailment in terms of satisfying assignments. -/
+theorem entails_ext : entails φ₁ φ₂ ↔ (∀ (τ : PropAssignment ν), τ ⊨ φ₁ → τ ⊨ φ₂) := by
+  have : ∀ τ, (φ₁.eval τ → φ₂.eval τ) ↔ φ₁.eval τ ≤ φ₂.eval τ := by
+    intro τ
+    cases (eval τ φ₁)
+    . simp
+    . simp only [true_implies]
+      exact ⟨fun h => h ▸ le_rfl, top_unique⟩
+  simp [sEntails, entails, satisfies, this]
+
+theorem entails_refl (φ : PropForm ν) : entails φ φ :=
+  fun _ => le_rfl
+theorem entails.trans : entails φ₁ φ₂ → entails φ₂ φ₃ → entails φ₁ φ₃ :=
+  fun h₁ h₂ τ => le_trans (h₁ τ) (h₂ τ)
+
+theorem entails_tr (φ : PropForm ν) : entails φ tr :=
+  fun _ => le_top
+theorem fls_entails (φ : PropForm ν) : entails fls φ :=
+  fun _ => bot_le
+
+theorem entails_disj_left (φ₁ φ₂ : PropForm ν) : entails φ₁ (disj φ₁ φ₂) :=
+  fun _ => le_sup_left
+theorem entails_disj_right (φ₁ φ₂ : PropForm ν) : entails φ₂ (disj φ₁ φ₂) :=
+  fun _ => le_sup_right
+theorem disj_entails : entails φ₁ φ₃ → entails φ₂ φ₃ → entails (disj φ₁ φ₂) φ₃ :=
+  fun h₁ h₂ τ => sup_le (h₁ τ) (h₂ τ)
+
+theorem conj_entails_left (φ₁ φ₂ : PropForm ν) : entails (conj φ₁ φ₂) φ₁ :=
+  fun _ => inf_le_left
+theorem conj_entails_right (φ₁ φ₂ : PropForm ν) : entails (conj φ₁ φ₂) φ₂ :=
+  fun _ => inf_le_right
+theorem entails_conj : entails φ₁ φ₂ → entails φ₁ φ₃ → entails φ₁ (conj φ₂ φ₃) :=
+  fun h₁ h₂ τ => le_inf (h₁ τ) (h₂ τ)
+
+theorem entails_disj_conj (φ₁ φ₂ φ₃ : PropForm ν) :
+    entails (conj (disj φ₁ φ₂) (disj φ₁ φ₃)) (disj φ₁ (conj φ₂ φ₃)) :=
+  fun _ => le_sup_inf
+
+theorem conj_neg_entails_fls (φ : PropForm ν) : entails (conj φ (neg φ)) fls :=
+  fun τ => BooleanAlgebra.inf_compl_le_bot (eval τ φ)
+
+theorem tr_entails_disj_neg (φ : PropForm ν) : entails tr (disj φ (neg φ)) :=
+  fun τ => BooleanAlgebra.top_le_sup_compl (eval τ φ)
+
+/-- Two formulas are semantically equivalent when they always evaluate to the same thing.
+
+This is a strong notion of equivalence.
+See `equivalentOver` for a weaker one. -/
+def equivalent (φ₁ φ₂ : PropForm ν) : Prop :=
+  ∀ (τ : PropAssignment ν), φ₁.eval τ = φ₂.eval τ
+
+theorem equivalent_iff_entails :
+    equivalent φ₁ φ₂ ↔ (entails φ₁ φ₂ ∧ entails φ₂ φ₁) := by
+  simp only [equivalent, entails]
+  aesop (add safe le_antisymm)
+
+theorem equivalent_ext :
+    equivalent φ₁ φ₂ ↔ (∀ (τ : PropAssignment ν), τ ⊨ φ₁ ↔ τ ⊨ φ₂) := by
+  simp only [equivalent_iff_entails, entails_ext]
+  aesop
+
+theorem equivalent_refl (φ : PropForm ν) : equivalent φ φ :=
+  fun _ => rfl
+theorem equivalent.symm : equivalent φ₁ φ₂ → equivalent φ₂ φ₁ :=
+  fun h τ => (h τ).symm
+theorem equivalent.trans : equivalent φ₁ φ₂ → equivalent φ₂ φ₃ → equivalent φ₁ φ₃ :=
+  fun h₁ h₂ τ => (h₁ τ).trans (h₂ τ)
+theorem entails.antisymm : entails φ₁ φ₂ → entails φ₂ φ₁ → equivalent φ₁ φ₂ :=
+  fun h₁ h₂ => equivalent_iff_entails.mpr ⟨h₁, h₂⟩
+
+end PropForm

--- a/LeanSAT/Model/ToMathlib.lean
+++ b/LeanSAT/Model/ToMathlib.lean
@@ -1,0 +1,21 @@
+/-
+Copyright (c) 2023 Wojciech Nawrocki. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Wojciech Nawrocki
+-/
+
+/-! Stuff that seems like it should be in std or mathlib. -/
+
+/-! Std.Logic or Std.Bool? -/
+
+@[simp] theorem Bool.eq_true_iff_eq_true_to_eq (a b : Bool) :
+  (a = true ↔ b = true) = (a = b) := by cases a <;> cases b <;> decide
+@[simp] theorem Bool.eq_false_iff_eq_false_to_eq (a b : Bool) :
+  (a = false ↔ b = false) = (a = b) := by cases a <;> cases b <;> decide
+
+/-- Notation typeclass for semantic entailment `⊨`. -/
+class SemanticEntails (α : Type u) (β : outParam $ Type v) where
+  entails : α → β → Prop
+
+infix:51 " ⊨ " => SemanticEntails.entails
+infix:51 " ⊭ " => fun M φ => ¬(M ⊨ φ)

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1694529238,
+        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1696757521,
+        "narHash": "sha256-cfgtLNCBLFx2qOzRLI6DHfqTdfWI+UbvsKYa3b3fvaA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "2646b294a146df2781b1ca49092450e8a32814e1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,16 @@
+{
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+  inputs.flake-utils.url = "github:numtide/flake-utils";
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system: let
+      pkgs = nixpkgs.legacyPackages.${system};
+    in {
+      devShells.default = pkgs.mkShell {
+        packages = with pkgs; [ 
+          bashInteractive
+          elan
+        ];
+      };
+    });
+}

--- a/lake-manifest.json
+++ b/lake-manifest.json
@@ -1,4 +1,4 @@
-{"version": 5,
+{"version": 6,
  "packagesDir": "lake-packages",
  "packages":
  [{"git":
@@ -10,6 +10,22 @@
     "inputRev?": "main",
     "inherited": false}},
   {"git":
+   {"url": "http://github.com/leanprover/std4.git",
+    "subDir?": null,
+    "rev": "f2df4ab8c0726fce3bafb73a5727336b0c3120ea",
+    "opts": {},
+    "name": "std",
+    "inputRev?": "main",
+    "inherited": false}},
+  {"git":
+   {"url": "https://github.com/leanprover-community/mathlib4.git",
+    "subDir?": null,
+    "rev": "69c11afc3834fd1d0ee62995c5aacc39dabf834c",
+    "opts": {},
+    "name": "mathlib",
+    "inputRev?": "master",
+    "inherited": false}},
+  {"git":
    {"url": "http://github.com/mhuisi/lean4-cli.git",
     "subDir?": null,
     "rev": "21dac2e9cc7e3cf7da5800814787b833e680b2fd",
@@ -18,10 +34,27 @@
     "inputRev?": "nightly",
     "inherited": true}},
   {"git":
-   {"url": "http://github.com/leanprover/std4.git",
+   {"url": "https://github.com/gebner/quote4",
     "subDir?": null,
-    "rev": "e8c27f7d90ee71470558efd1bc197fe55068c748",
+    "rev": "a387c0eb611857e2460cf97a8e861c944286e6b2",
     "opts": {},
-    "name": "std",
-    "inputRev?": "main",
-    "inherited": false}}]}
+    "name": "Qq",
+    "inputRev?": "master",
+    "inherited": true}},
+  {"git":
+   {"url": "https://github.com/JLimperg/aesop",
+    "subDir?": null,
+    "rev": "41c6370eb2f0c9052bee6af0e0a017b9ba8da2b8",
+    "opts": {},
+    "name": "aesop",
+    "inputRev?": "master",
+    "inherited": true}},
+  {"git":
+   {"url": "https://github.com/EdAyers/ProofWidgets4",
+    "subDir?": null,
+    "rev": "27715d1daf32b9657dc38cd52172d77b19bde4ba",
+    "opts": {},
+    "name": "proofwidgets",
+    "inputRev?": "v0.0.18",
+    "inherited": true}}],
+ "name": "«lean-sat»"}

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -11,5 +11,6 @@ lean_exe run_examples {
   root := `Examples
 }
 
-require std from git "http://github.com/leanprover/std4.git" @ "main"
+-- Note: `std` is not required so that Lake selects a version matching mathlib.
 require waterfall from git "http://github.com/JamesGallicchio/waterfall.git" @ "main"
+require mathlib from git "https://github.com/leanprover-community/mathlib4.git" @ "master"

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:nightly-2023-08-23
+leanprover/lean4:v4.2.0-rc1


### PR DESCRIPTION
A little warmup PR. We require mathlib, define propositional formulas, entailment, and equivalence. (I also snuck in a Nix flake if that's alright.)

@JamesGallicchio I understand you wanted `main` protected? I am making this PR against a new `dev` branch for that.