### PR TITLE
Removed literal type L in EncCNF and downstream

### DIFF
--- a/Examples/ApproxMC.lean
+++ b/Examples/ApproxMC.lean
@@ -20,7 +20,7 @@ def main : IO Unit := do
   let y : Fin 3 := 1
   let z : Fin 3 := 2
 
-  let enc : EncCNF (Literal (Fin 3)) Unit := do
+  let enc : EncCNF (Fin 3) Unit := do
     Subtype.val tseitin[ {x} ∧ {y} ∧ {z} ∨ ¬{x} ∧ ¬{y} ]
 
   let ((),state) := enc.run

--- a/Examples/GraphColoring.lean
+++ b/Examples/GraphColoring.lean
@@ -102,13 +102,12 @@ def graphColoring (G : Graph n) : PropPred (ColorVars n) := fun τ =>
   (τ |> edgeConstraints G)
 
 ------------------------------------------------------------------------
--- Now we express the graph coloring problem into a CNF
+-- Now we express the graph coloring problem as a CNF
 /-! # CNF -/
 
 open Encode VEncCNF LitVar
 
-abbrev L (n : Nat) := Literal (ColorVars n)
-abbrev VCnf (n : Nat) := VEncCNF (L n) Unit
+abbrev VCnf (n : Nat) := VEncCNF (ColorVars n) Unit
 
 def vertexColorClause (v : Fin n) : VCnf n (eachVertexGetsAColor v) :=
   (addClause #[mkPos <| blue v, mkPos <| red v, mkPos <| green v, mkPos <| yellow v])

--- a/Examples/PigeonHole.lean
+++ b/Examples/PigeonHole.lean
@@ -27,7 +27,7 @@ def pigeonsInHole (h : Fin n) : List (Literal <| Var n) :=
 def holesWithPigeon (p : Fin (n+1)) : List (Literal (Var n)) :=
   List.finRange n |>.map (Literal.pos <| Var.mk p ·)
 
-def encoding (n) : VEncCNF (Literal (Var n)) Unit (fun τ =>
+def encoding (n) : VEncCNF (Var n) Unit (fun τ =>
     (∀ p, ∃ h, τ (Var.mk p h)) ∧
     (∀ h, atMost 1 (Multiset.ofList <| pigeonsInHole h) τ)
   ) :=

--- a/LeanSAT/Encode/Card.lean
+++ b/LeanSAT/Encode/Card.lean
@@ -12,28 +12,26 @@ namespace LeanSAT.Encode
 
 open VEncCNF Model PropFun
 
-variable [LitVar L ν] [LawfulLitVar L ν] [DecidableEq L] [DecidableEq ν]
-
-def card (lits : Multiset L) (τ : PropAssignment ν) : Nat :=
+def card (lits : Multiset (Literal ν)) (τ : PropAssignment ν) : Nat :=
   lits.countP (τ ⊨ LitVar.toPropFun ·)
 
-noncomputable def cardPred (lits : Multiset L) (P : Nat → Prop) [DecidablePred P] :=
+noncomputable def cardPred (lits : Multiset (Literal ν)) (P : Nat → Prop) [DecidablePred P] :=
   fun τ => P (card lits τ)
 
-@[simp] theorem satisfies_cardPred (lits : Multiset L) (P) [DecidablePred P] (τ)
+@[simp] theorem satisfies_cardPred (lits : Multiset (Literal ν)) (P) [DecidablePred P] (τ)
   : cardPred lits P τ ↔ P (card lits τ) := by
   unfold cardPred; simp
 
-noncomputable abbrev atMost (k : Nat) (lits : Multiset L) := cardPred lits (· ≤ k)
-noncomputable abbrev atLeast (k : Nat) (lits : Multiset L) := cardPred lits (· ≥ k)
+noncomputable abbrev atMost (k : Nat) (lits : Multiset (Literal ν)) := cardPred lits (· ≤ k)
+noncomputable abbrev atLeast (k : Nat) (lits : Multiset (Literal ν)) := cardPred lits (· ≥ k)
 
 theorem ofList_eq_map_get (L : List α)
   : Multiset.ofList L = (Finset.univ.val.map fun i => L.get i) := by
   conv => lhs; rw [← List.finRange_map_get (l := L)]
 
 @[inline]
-def amoPairwise (lits : Array L) :
-    VEncCNF L Unit (atMost 1 (Multiset.ofList lits.data)) := (
+def amoPairwise (lits : Array (Literal ν)) :
+    VEncCNF ν Unit (atMost 1 (Multiset.ofList lits.data)) := (
   -- for every pair x,y of literals in `lits`, they can't both be true
   for_all (Array.ofFn id) fun (i : Fin lits.size) =>
     for_all (Array.ofFn (fun (diff : Fin (lits.size - i.succ)) =>

--- a/LeanSAT/Solver/Dimacs.lean
+++ b/LeanSAT/Solver/Dimacs.lean
@@ -126,7 +126,7 @@ def parseResult (maxVar : Nat) (s : String) : Except String Solver.Res := do
   | _ => .error  "Expected `s <UNSATISFIABLE|SATISFIABLE>`, got `{first}`"
 
 
-def fromFileEnc (cnfFile : String) : IO (Encode.EncCNF.State ILit IVar) := do
+def fromFileEnc (cnfFile : String) : IO (Encode.EncCNF.State IVar) := do
   let contents ← IO.FS.withFile cnfFile .read (·.readToEnd)
   let {vars, clauses} ← IO.ofExcept <| Dimacs.parseFormula contents
   return {


### PR DESCRIPTION
As per James' request, `EncCNF` and `VEncCNF` now no longer refer to an explicit literal type `L`, instead using `Literal v` everywhere (which has already been proven to be a `LawfulLitVar`, etc.).

Downstream affected files, including `Dimacs.lean` and the encodings, have been fixed.