### PR TITLE
Fix shared cnf in withTemps under the new compiler

### DIFF
--- a/Trestle/Encode/Cardinality/Sinz.lean
+++ b/Trestle/Encode/Cardinality/Sinz.lean
@@ -209,7 +209,7 @@ where
     )
 
 
-/-
+/--
 info: p cnf 13 11
 -11 12 0
 -12 13 0
@@ -223,7 +223,7 @@ info: p cnf 13 11
 12 -13 3 0
 13 0
 -/
---#guard_msgs in
+#guard_msgs in
 #eval! (show VEncCNF (Fin 10) Unit _ from
           sinzExactlyOne #[Literal.pos 0, Literal.pos 1, Literal.pos 2]
         ).1.run.2.cnf |> Solver.Dimacs.printRichCnf (IO.print)

--- a/Trestle/Encode/EncCNF.lean
+++ b/Trestle/Encode/EncCNF.lean
@@ -415,25 +415,46 @@ def nextVar_mono_of_eq {e : EncCNF ν α} (h : e.1 s = (a, s')) :
   have := h ▸ e.2 s
   exact this
 
+/-- Tempify the state and extract its `vMap` in one opaque step.
+
+`@[noinline]` is essential here: it forces the compiler to consume `s` before
+the inner encoder runs. Without it, the LCNF simplifier substitutes the
+`s.vMap` projection to its use site after the inner run, which keeps `s` (and
+hence its `cnf`) alive during the whole run; every `addClause` inside then
+sees a shared `cnf` and copies the entire array. -/
+@[noinline]
+def LawfulState.withTempsAux [IndexType ι] [LawfulIndexType ι]
+    (s : LawfulState ν) (names : Option (ι → String)) :
+    LawfulState (ν ⊕ ι) × (ν → IVar) :=
+  (s.withTemps names, s.vMap)
+
 def withTemps (ι) [IndexType ι] [LawfulIndexType ι] (e : EncCNF (ν ⊕ ι) α) (names : Option (ι → String) := none) : EncCNF ν α :=
   ⟨ fun s =>
-    let vMap := s.vMap
-    let vMapInj := s.vMapInj
-    let tempify := s.withTemps names
+    match haux : LawfulState.withTempsAux s names with
+    | (tempify, vMap) =>
     match h : e.1 tempify with
     | (a,s') =>
     (a, s'.withoutTemps vMap (by
+        simp [LawfulState.withTempsAux, Prod.ext_iff] at haux
+        obtain ⟨htemp, hvmap⟩ := haux
+        subst htemp; subst hvmap
         intro v; rw [IVar.lt_def]
         apply Nat.lt_of_lt_of_le (m := s.nextVar.val)
         · apply s.vMapLt
-        · apply Nat.le_trans (m := tempify.nextVar.val)
-          · simp [tempify, LawfulState.withTemps, State.withTemps]
+        · apply Nat.le_trans (m := (s.withTemps names).nextVar.val)
+          · simp [LawfulState.withTemps, State.withTemps]
           · rw [← IVar.le_def]
             exact e.nextVar_mono_of_eq h
-      ) vMapInj)
-  , by simp [LawfulState.withoutTemps, State.withoutTemps]
-       intro s; split; simp; have := e.nextVar_mono_of_eq ‹_›
-       simp [LawfulState.withTemps, State.withTemps] at this
+      ) (by
+        simp [LawfulState.withTempsAux, Prod.ext_iff] at haux
+        exact haux.2 ▸ s.vMapInj))
+  , by intro s
+       dsimp only
+       split
+       next a s' h' =>
+       simp [LawfulState.withoutTemps, State.withoutTemps]
+       have := e.nextVar_mono_of_eq h'
+       simp [LawfulState.withTempsAux, LawfulState.withTemps, State.withTemps] at this
        apply Nat.le_trans (m := (s.nextVar + IndexType.card ι).val)
        · apply Nat.le_add_right
        · exact (PNat.coe_le_coe ..).mp this⟩

--- a/Trestle/Encode/EncCNF.lean
+++ b/Trestle/Encode/EncCNF.lean
@@ -59,7 +59,7 @@ def addClause (C : Clause (Literal ν)) (s : State ν) : State ν :=
         dbgTraceIfShared
           "State.addClause: cnf is shared (performance bug!)"
           cnf
-      cnf.addClause (C.map _ vMap)
+      cnf.addClause (C.map vMap)
   }
 
 @[simp] theorem toPropFun_addClause (C : Clause (Literal ν)) (s)

--- a/Trestle/Encode/VEncCNF.lean
+++ b/Trestle/Encode/VEncCNF.lean
@@ -163,7 +163,7 @@ def withTemps (ι) [IndexType ι] [LawfulIndexType ι] {P : PropAssignment (ν �
     unfold ls_post'; clear ls_post'
     generalize retVal_def : (EncCNF.withTemps ι ve.val _).val ls_pre = retVal
     -- let's get through a nasty match in withTemps
-    dsimp [EncCNF.withTemps] at retVal_def
+    dsimp [EncCNF.withTemps, EncCNF.LawfulState.withTempsAux] at retVal_def
     split at retVal_def; next a ls_post_withTemps pre_to_post =>
     generalize ls_post_def : ls_post_withTemps.withoutTemps _ _ _ = ls_post at retVal_def
     subst retVal; dsimp


### PR DESCRIPTION
## Problem

Since the switch to the new code generator (Lean v4.22), builds on `dev` emit

```
shared RC State.addClause: cnf is shared (performance bug!)
```

e.g. 10× for the single `#eval!` in `Trestle/Encode/Cardinality/Sinz.lean`, and the corresponding `#guard_msgs` test had to be disabled.

## Root cause

In `EncCNF.withTemps`, the source reads `let vMap := s.vMap` *before* running the inner encoder so that `s` dies early. The new LCNF simplifier treats the projection as a free-to-move value and substitutes it to its use site — *after* the inner run. The resulting IR does `inc s`, runs the whole inner encoder, and only then `proj s.vMap; dec s`. So the outer state, and hence its `cnf`, stays live across the entire inner run: the first `addClause` in every `withTemps` scope sees a shared `cnf` and copies the whole array. Since every `tseitin[...]` fragment opens its own scope, encodings degrade to one full CNF copy per fragment (quadratic overall).

## Fix

Extract the tempified state and the surviving `vMap` in one step through a `@[noinline]` helper (`LawfulState.withTempsAux`) that is consumed before the inner run, and destructure its result with `match`. The compiler can then no longer move any read of `s` past the run. Checked the compiled IR: the pair is projected and freed before the inner call, and nothing references `s` afterwards.

Two notes:

- A getter returning the bare function (`@[noinline] def vMapGet s := s.vMap`) makes things *worse*: it compiles to a `pap` capturing the whole state, which then lives inside the restored `vMap` forever — the same bug the `!!!!!` comment in this file describes. The surviving value must be a saturated object, hence the pair.
- The first commit is an unrelated one-line compile fix (`C.map _ vMap` → `C.map vMap`) that `dev` currently needs to build at all; drop it if you already have your own version.

## Verification

Full `lake build` on v4.28.0: succeeds with zero sharing warnings (previously Sinz ×10, Tseitin ×3). The `#guard_msgs` test in Sinz.lean is re-enabled and passes. Isolated `#eval` tests of plain `EncCNF`, `seq`, `for_all`, nested/sequential `withTemps` are all silent.

The underlying compiler behavior (projection substitution extending an object's lifetime past a call, defeating destructive updates) still reproduces on v4.32.2 and is probably worth an upstream lean4 issue; dumping the IR of a clone of `withTemps` with `set_option trace.compiler.ir.result true` demonstrates it directly.